### PR TITLE
[feat/#56] Login -> Profile 페이지 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import Header from "./components/Header/Header.jsx";
 import SideMenubar from "./components/SideMenubar/SideMenubar.jsx";
 import MiniSideMenuBar from "./components/MiniSideMenuBar/MinisideMenuBar.jsx";
 import "./App.css";
+import { ProfileProvider } from "./context/ProfileContext.jsx";
 
 function AppLayout() {
   const location = useLocation();
@@ -87,7 +88,9 @@ function App() {
 function AppWithRouter() {
   return (
     <Router>
-      <App />
+      <ProfileProvider>
+        <App />
+      </ProfileProvider>
     </Router>
   );
 }

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import axios from "axios";
 
-const API_BASE_URL = 'http://localhost:8080/api/v1/users';
+const API_BASE_URL = "http://localhost:8080/api/v1/users";
 
 export const registerUser = async (userData) => {
   try {
@@ -8,11 +8,21 @@ export const registerUser = async (userData) => {
     return response.data;
   } catch (error) {
     if (error.response) {
-      console.error('Error Response:', error.response.data);
+      console.error("Error Response:", error.response.data);
       throw error.response.data;
     } else {
-      console.error('Network or Unknown Error:', error);
-      throw { message: '서버와 연결할 수 없습니다.' };
+      console.error("Network or Unknown Error:", error);
+      throw { message: "서버와 연결할 수 없습니다." };
     }
+  }
+};
+
+export const getAllUsers = async () => {
+  try {
+    const response = await axios.get(API_BASE_URL);
+    return response.data; // 사용자 목록 배열
+  } catch (error) {
+    console.error("전체 유저 조회 실패", error);
+    throw error;
   }
 };

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -17,12 +17,18 @@ export const registerUser = async (userData) => {
   }
 };
 
-export const getAllUsers = async () => {
+// 🔄 로그인 요청 API 추가
+export const loginUser = async (credentials) => {
   try {
-    const response = await axios.get(API_BASE_URL);
-    return response.data; // 사용자 목록 배열
+    const response = await axios.post(`${API_BASE_URL}/login`, credentials);
+    return response.data;
   } catch (error) {
-    console.error("전체 유저 조회 실패", error);
-    throw error;
+    if (error.response) {
+      console.error("Login Error:", error.response.data);
+      throw error.response.data;
+    } else {
+      console.error("Network or Unknown Error:", error);
+      throw { message: "서버와 연결할 수 없습니다." };
+    }
   }
 };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
 import "./Header.css";
 
 import logoImg from "../../assets/react.svg";
-import profileImg from "../../assets/프로필이미지.png";
+import { ProfileContext } from "../../context/ProfileContext";
 
 function Header() {
+  const { profileImage } = useContext(ProfileContext);
+
   return (
     <header className="header">
       <div className="brand">
@@ -14,7 +16,7 @@ function Header() {
         <div className="siteName">AdCanvas</div>
       </div>
       <div className="profile">
-        <img src={profileImg} alt="Profile" />
+        <img src={profileImage} alt="Profile" />
       </div>
     </header>
   );

--- a/src/components/SideMenuBar/SideMenuBar.jsx
+++ b/src/components/SideMenuBar/SideMenuBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import "./SideMenubar.css";
 
@@ -14,14 +14,20 @@ import Help from "../subcomponents/Help/Help";
 
 import { motion } from "framer-motion";
 import { animation } from "../../styles/motion";
+import { ProfileContext } from "../../context/ProfileContext";
 
 function SideMenubar() {
   const location = useLocation();
   const currentPath = location.pathname;
   const [showHelp, setShowHelp] = useState(false);
+  const { logout } = useContext(ProfileContext);
 
   // 유틸: 현재 경로가 메뉴 경로와 일치하는지 확인
   const isCurrent = (path) => currentPath.startsWith(path);
+
+  const handleLogout = () => {
+    logout(); // 상태와 localStorage 초기화
+  };
 
   return (
     <nav className="sideMenubar">
@@ -199,13 +205,8 @@ function SideMenubar() {
           <span className={`menu-text${showHelp ? " active" : ""}`}>Help</span>
         </li>
         {/* 일단 Logout Account만 만들고 나중에 로그인 연동을 하면, 로그인 여부에 따라서 Login Account/Logout Account로 구현하면 될 것같음 */}
-        <li className="menu-item">
-          <NavLink
-            to="/login"
-            className={({ isActive }) =>
-              "menu-link" + (isActive ? " active" : "")
-            }
-          >
+        <li className="menu-item" onClick={handleLogout}>
+          <NavLink to="/login">
             <img src={LogoutImg} alt="Logout" className="menu-icon" />
             <span className="menu-text">Logout Account</span>
           </NavLink>

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -4,38 +4,59 @@ import profileIcon from "../assets/profile-icon.png";
 export const ProfileContext = createContext();
 
 export const ProfileProvider = ({ children }) => {
-  const [profileImage, setProfileImage] = useState(() => {
-    return localStorage.getItem("profileImage") || profileIcon;
-  });
-
   const [profileName, setProfileName] = useState(() => {
     return localStorage.getItem("profileName") || "";
   });
 
-  // ✅ 로그아웃 함수
-  const logout = () => {
-    localStorage.removeItem("profileImage");
-    localStorage.removeItem("profileName");
-    setProfileImage(profileIcon);
-    setProfileName("");
+  const [email, setEmail] = useState(() => {
+    return localStorage.getItem("email") || "";
+  });
+
+  const getStoredImage = (email) => {
+    const stored = localStorage.getItem("userProfileImages");
+    const images = stored ? JSON.parse(stored) : {};
+    return images[email] || profileIcon;
   };
 
-  useEffect(() => {
-    localStorage.setItem("profileImage", profileImage);
-  }, [profileImage]);
+  const [profileImage, setProfileImage] = useState(() =>
+    getStoredImage(localStorage.getItem("email"))
+  );
 
   useEffect(() => {
     localStorage.setItem("profileName", profileName);
   }, [profileName]);
 
+  useEffect(() => {
+    localStorage.setItem("email", email);
+  }, [email]);
+
+  useEffect(() => {
+    if (email) {
+      const stored = localStorage.getItem("userProfileImages");
+      const images = stored ? JSON.parse(stored) : {};
+      images[email] = profileImage;
+      localStorage.setItem("userProfileImages", JSON.stringify(images));
+    }
+  }, [profileImage, email]);
+
+  const logout = () => {
+    localStorage.removeItem("profileName");
+    localStorage.removeItem("email");
+    setProfileName("");
+    setEmail("");
+    setProfileImage(profileIcon); // 기본 이미지로 초기화
+  };
+
   return (
     <ProfileContext.Provider
       value={{
-        profileImage,
-        setProfileImage,
         profileName,
         setProfileName,
-        logout, // 👈 로그아웃 추가
+        profileImage,
+        setProfileImage,
+        email,
+        setEmail,
+        logout,
       }}
     >
       {children}

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -4,6 +4,10 @@ import profileIcon from "../assets/profile-icon.png";
 export const ProfileContext = createContext();
 
 export const ProfileProvider = ({ children }) => {
+  const [id, setId] = useState(() => {
+    return localStorage.getItem("id") || "";
+  });
+
   const [profileName, setProfileName] = useState(() => {
     return localStorage.getItem("profileName") || "";
   });
@@ -23,6 +27,10 @@ export const ProfileProvider = ({ children }) => {
   );
 
   useEffect(() => {
+    localStorage.setItem("id", id); // ✅ "id"라는 key로 저장
+  }, [id]);
+
+  useEffect(() => {
     localStorage.setItem("profileName", profileName);
   }, [profileName]);
 
@@ -40,16 +48,20 @@ export const ProfileProvider = ({ children }) => {
   }, [profileImage, email]);
 
   const logout = () => {
+    localStorage.removeItem("id"); // ✅ 로그아웃 시 "id" 삭제
     localStorage.removeItem("profileName");
     localStorage.removeItem("email");
+    setId("");
     setProfileName("");
     setEmail("");
-    setProfileImage(profileIcon); // 기본 이미지로 초기화
+    setProfileImage(profileIcon);
   };
 
   return (
     <ProfileContext.Provider
       value={{
+        id,
+        setId,
         profileName,
         setProfileName,
         profileImage,

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -1,0 +1,14 @@
+import { createContext, useState } from "react";
+import profileIcon from "../assets/profile-icon.png"; // 기본 이미지
+
+export const ProfileContext = createContext();
+
+export const ProfileProvider = ({ children }) => {
+  const [profileImage, setProfileImage] = useState(profileIcon);
+
+  return (
+    <ProfileContext.Provider value={{ profileImage, setProfileImage }}>
+      {children}
+    </ProfileContext.Provider>
+  );
+};

--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -1,13 +1,43 @@
-import { createContext, useState } from "react";
-import profileIcon from "../assets/profile-icon.png"; // 기본 이미지
+import { createContext, useState, useEffect } from "react";
+import profileIcon from "../assets/profile-icon.png";
 
 export const ProfileContext = createContext();
 
 export const ProfileProvider = ({ children }) => {
-  const [profileImage, setProfileImage] = useState(profileIcon);
+  const [profileImage, setProfileImage] = useState(() => {
+    return localStorage.getItem("profileImage") || profileIcon;
+  });
+
+  const [profileName, setProfileName] = useState(() => {
+    return localStorage.getItem("profileName") || "";
+  });
+
+  // ✅ 로그아웃 함수
+  const logout = () => {
+    localStorage.removeItem("profileImage");
+    localStorage.removeItem("profileName");
+    setProfileImage(profileIcon);
+    setProfileName("");
+  };
+
+  useEffect(() => {
+    localStorage.setItem("profileImage", profileImage);
+  }, [profileImage]);
+
+  useEffect(() => {
+    localStorage.setItem("profileName", profileName);
+  }, [profileName]);
 
   return (
-    <ProfileContext.Provider value={{ profileImage, setProfileImage }}>
+    <ProfileContext.Provider
+      value={{
+        profileImage,
+        setProfileImage,
+        profileName,
+        setProfileName,
+        logout, // 👈 로그아웃 추가
+      }}
+    >
       {children}
     </ProfileContext.Provider>
   );

--- a/src/pages/Login/Login.css
+++ b/src/pages/Login/Login.css
@@ -237,3 +237,10 @@
 .login__forgot {
   display: none;
 }
+
+.login__error {
+  color: red;
+  margin: 10px 0; /* 위아래 여백 축소 */
+  font-size: 16px;
+  line-height: 1.2;
+}

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -160,11 +160,7 @@ function Login() {
         />
         <br />
 
-        {error && (
-          <p className="login__normal" style={{ color: "red" }}>
-            {error}
-          </p>
-        )}
+        {error && <p className="login__normal login__error">{error}</p>}
 
         {isSignIn && (
           <p className="login__normal login__forgot">Forgot your password?</p>

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -15,14 +15,10 @@ function Login() {
     password: "",
   });
   const [error, setError] = useState("");
-  const { setProfileName, setEmail, setProfileImage } =
+  const { setProfileName, setEmail, setProfileImage, setId } =
     useContext(ProfileContext);
 
   const handleToggle = () => setIsSignIn((prev) => !prev);
-
-  const handleKeyDown = (e) => {
-    if (e.key === "Enter") navigate("/home");
-  };
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -56,8 +52,9 @@ function Login() {
         password: formData.password,
       };
 
-      const response = await loginUser(userData); // { name, email }
+      const response = await loginUser(userData); // { id, name, email }
 
+      setId(response.id); // 🔹 ID 저장
       setProfileName(response.name);
       setEmail(response.email);
 
@@ -145,7 +142,6 @@ function Login() {
           className="login__normal login__input"
           value={formData.email}
           onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
         />
         <br />
 
@@ -156,7 +152,6 @@ function Login() {
           className="login__normal login__input"
           value={formData.password}
           onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
         />
         <br />
 
@@ -174,14 +169,7 @@ function Login() {
         </button>
       </div>
     );
-  }, [
-    isSignIn,
-    formData,
-    error,
-    handleInputChange,
-    handleKeyDown,
-    handleSignUp,
-  ]);
+  }, [isSignIn, formData, error, handleInputChange, handleSignUp]);
 
   return (
     <article className="loginPage">

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -4,6 +4,7 @@ import "@fortawesome/fontawesome-free/css/all.min.css";
 import "./Login.css";
 import { loginUser, registerUser } from "../../api/user";
 import { ProfileContext } from "../../context/ProfileContext";
+import profileIcon from "../../assets/profile-icon.png";
 
 function Login() {
   const [isSignIn, setIsSignIn] = useState(false);
@@ -14,7 +15,8 @@ function Login() {
     password: "",
   });
   const [error, setError] = useState("");
-  const { setProfileName } = useContext(ProfileContext);
+  const { setProfileName, setEmail, setProfileImage } =
+    useContext(ProfileContext);
 
   const handleToggle = () => setIsSignIn((prev) => !prev);
 
@@ -54,14 +56,18 @@ function Login() {
         password: formData.password,
       };
 
-      const response = await loginUser(userData);
-      console.log("로그인 성공:", response);
-
-      // 기존 localStorage 클리어 (중복 방지)
-      localStorage.removeItem("profileImage");
-      localStorage.removeItem("profileName");
+      const response = await loginUser(userData); // { name, email }
 
       setProfileName(response.name);
+      setEmail(response.email);
+
+      // 이메일별 저장된 이미지 로드
+      const storedImages = JSON.parse(
+        localStorage.getItem("userProfileImages") || "{}"
+      );
+      const image = storedImages[response.email];
+      setProfileImage(image || profileIcon);
+
       setError("");
       navigate("/home");
     } catch (error) {

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import "./Login.css";
-import { registerUser } from "../../api/user";
+import { getAllUsers, registerUser } from "../../api/user";
 
 function Login() {
   const [isSignIn, setIsSignIn] = useState(false);
@@ -10,7 +10,7 @@ function Login() {
   const [formData, setFormData] = useState({
     username: "",
     email: "",
-    password: ""
+    password: "",
   });
   const [error, setError] = useState("");
 
@@ -22,28 +22,49 @@ function Login() {
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [name]: value
+      [name]: value,
     }));
   };
 
   const handleSignUp = async (e) => {
-  e.preventDefault();
-  try {
-    const response = await registerUser({
-      name: formData.username,
-      email: formData.email,
-      password: formData.password
-    });
-    console.log("Registration successful:", response);
-    setIsSignIn(true);
-    setFormData({ username: "", email: "", password: "" });
-    setError("");
-  } catch (error) {
-    setError(error.message || "회원가입 중 오류가 발생했습니다.");
-  }
-};
+    e.preventDefault();
+    try {
+      const response = await registerUser({
+        name: formData.username,
+        email: formData.email,
+        password: formData.password,
+      });
+      console.log("Registration successful:", response);
+      setIsSignIn(true);
+      setFormData({ username: "", email: "", password: "" });
+      setError("");
+    } catch (error) {
+      setError(error.message || "회원가입 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleSignIn = async () => {
+    try {
+      const users = await getAllUsers();
+
+      const matchedUser = users.find(
+        (user) =>
+          user.email === formData.email && user.password === formData.password
+      );
+
+      if (matchedUser) {
+        console.log("로그인 성공:", matchedUser);
+        setError("");
+        navigate("/home"); // 홈으로 이동
+      } else {
+        setError("이메일 또는 비밀번호가 일치하지 않습니다.");
+      }
+    } catch (error) {
+      setError("서버 오류로 로그인할 수 없습니다.");
+    }
+  };
 
   const WelcomeSection = () => (
     <div
@@ -129,21 +150,32 @@ function Login() {
         />
         <br />
 
-        {error && <p className="login__normal" style={{ color: "red" }}>{error}</p>}
+        {error && (
+          <p className="login__normal" style={{ color: "red" }}>
+            {error}
+          </p>
+        )}
 
         {isSignIn && (
           <p className="login__normal login__forgot">Forgot your password?</p>
         )}
 
-        <button 
+        <button
           className="b-button login__normal"
-          onClick={!isSignIn ? handleSignUp : undefined}
+          onClick={isSignIn ? handleSignIn : handleSignUp}
         >
           {isSignIn ? "SIGN IN" : "SIGN UP"}
         </button>
       </div>
     );
-  }, [isSignIn, formData, error, handleInputChange, handleKeyDown, handleSignUp]);
+  }, [
+    isSignIn,
+    formData,
+    error,
+    handleInputChange,
+    handleKeyDown,
+    handleSignUp,
+  ]);
 
   return (
     <article className="loginPage">
@@ -155,7 +187,7 @@ function Login() {
         }}
       >
         <div className="p-button login__normal" onClick={handleToggle}>
-          {isSignIn ? "SIGN IN" : "SIGN UP"}
+          {isSignIn ? "SIGN UP" : "SIGN IN"}
         </div>
       </div>
 

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import "./Login.css";
-import { getAllUsers, registerUser } from "../../api/user";
+import { loginUser, registerUser } from "../../api/user";
+import { ProfileContext } from "../../context/ProfileContext";
 
 function Login() {
   const [isSignIn, setIsSignIn] = useState(false);
@@ -13,6 +14,7 @@ function Login() {
     password: "",
   });
   const [error, setError] = useState("");
+  const { setProfileName } = useContext(ProfileContext);
 
   const handleToggle = () => setIsSignIn((prev) => !prev);
 
@@ -47,22 +49,24 @@ function Login() {
 
   const handleSignIn = async () => {
     try {
-      const users = await getAllUsers();
+      const userData = {
+        email: formData.email,
+        password: formData.password,
+      };
 
-      const matchedUser = users.find(
-        (user) =>
-          user.email === formData.email && user.password === formData.password
-      );
+      const response = await loginUser(userData);
+      console.log("로그인 성공:", response);
 
-      if (matchedUser) {
-        console.log("로그인 성공:", matchedUser);
-        setError("");
-        navigate("/home"); // 홈으로 이동
-      } else {
-        setError("이메일 또는 비밀번호가 일치하지 않습니다.");
-      }
+      // 기존 localStorage 클리어 (중복 방지)
+      localStorage.removeItem("profileImage");
+      localStorage.removeItem("profileName");
+
+      setProfileName(response.name);
+      setError("");
+      navigate("/home");
     } catch (error) {
-      setError("서버 오류로 로그인할 수 없습니다.");
+      console.error("로그인 오류:", error);
+      setError(error.message || "이메일 또는 비밀번호가 일치하지 않습니다.");
     }
   };
 

--- a/src/pages/Profile/Profile.css
+++ b/src/pages/Profile/Profile.css
@@ -52,7 +52,7 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: 125px;
+  top: 170px;
   left: 560px;
 }
 .profilePage__content__info__name {

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./Profile.css";
 import editIcon from "../../assets/profile-edit-btn-1.png";
@@ -8,13 +8,15 @@ import instaIcon from "../../assets/profile-insta-icon.png";
 import GradientBox from "../../components/GradientBox/GradientBox";
 import imageIcon from "../../assets/AI Images.png";
 import uploadIcon from "../../assets/uploadIcon.png";
+import { ProfileContext } from "../../context/ProfileContext";
 
 function Profile() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [showImageUploader, setShowImageUploader] = useState(false);
-  const [profileImage, setProfileImage] = useState(profileIcon);
+  // const [profileImage, setProfileImage] = useState(profileIcon);
   const fileInputRef = useRef(null);
   const navigate = useNavigate();
+  const { profileImage, setProfileImage } = useContext(ProfileContext);
 
   const toggleEditMode = () => setIsEditMode((prev) => !prev);
 
@@ -140,7 +142,7 @@ function Profile() {
             </button>
           </div>
 
-          <div className="profilePage__content__info__insta">
+          {/* <div className="profilePage__content__info__insta">
             <img src={instaIcon} alt="인스타 아이콘" />
             {isEditMode ? (
               <button className="profilePage__content__info__insta__login">
@@ -151,7 +153,7 @@ function Profile() {
                 chill_guy
               </span>
             )}
-          </div>
+          </div> */}
         </div>
       </article>
     </section>

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -16,7 +16,8 @@ function Profile() {
   // const [profileImage, setProfileImage] = useState(profileIcon);
   const fileInputRef = useRef(null);
   const navigate = useNavigate();
-  const { profileImage, setProfileImage } = useContext(ProfileContext);
+  const { profileImage, setProfileImage, profileName } =
+    useContext(ProfileContext);
 
   const toggleEditMode = () => setIsEditMode((prev) => !prev);
 
@@ -124,7 +125,7 @@ function Profile() {
           <div className="profilePage__content__info__name">
             닉네임:
             <span className="profilePage__content__info__name__nickname">
-              Chill guy
+              {profileName || "닉네임 없음"}
             </span>
           </div>
           <div className="profilePage__content__info__btn">


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

Login -> Profile 페이지 연동하기

### ✨ Description

<!-- write down the work details and show the execution results. -->

1. 로그인 기능과 해당 로그인한 유저의 데이터를 Profile 페이지에도 연동하기 => 영상에서 확인
- name이 잘 넘어감
![image](https://github.com/user-attachments/assets/7c03d3e4-a0b2-4915-b8c6-4b41608cdb04)
- 해당 유저 정보를 전역으로 저장하는 context폴더 안에 ProfileContext.jsx를 구현함

2. Profile 페이지에서 프로필 이미지를 변경하고, 새로고침이나 로그아웃 후 다시 들어와도 변경했던 프로필 이미지가 그대로 유지되어 있음(Header에도 유지됨) => 영상에서 확인
- localStorage로 프로필 이미지를 관리했음!

3. Login.jsx에서 handleKeyDown(엔터하면 홈 화면으로 넘어가지는 거)은 코드 삭제함
-  급하면 http://localhost:5173/home 이런식으로 주소창 이용!

4. 로그인 여부에 따라 로그인이 되어 있지 않으면 홈 화면으로 넘어가지 못하게 할지, 아니면 홈 화면은 넘어가게 하고 몇몇 페이지(AI Image, AI Video, My Creatives, Profile)만 넘어가게 못하게 할지 고민임 아직 거기까지는 구현하지 않았음
- 개인적으로 그냥 로그인이 되어있지 않으면 홈 화면 및 모든 페이지 넘어가지 못하게 하는게 나을듯?

5. 로그인 페이지에서 에러 메시지 크기와 여백을 조정함(에러 메시지가 떠도 버튼이 창 밖으로 안나게끔)

6. 로그인시 로컬스토리지에 "id"도 저장되게 추가함
![image](https://github.com/user-attachments/assets/bbd2c22e-ce16-4a5f-b41b-354cba2a5943)

7. Profile 페이지에서 "인스타 연동하기" 기능 없애자고 5/14 회의에서 얘기해서, "인스타 연동하기" 버튼을 삭제함

영상 (동영상 소리는 꺼주세요, 모르고 같이 들어가게 했네요ㅠ)


https://github.com/user-attachments/assets/bb293789-8d9b-4558-8115-8e2b2a8f69ef


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #56 
